### PR TITLE
Adding stairsplus support

### DIFF
--- a/my_door_wood/depends.txt
+++ b/my_door_wood/depends.txt
@@ -1,0 +1,1 @@
+moreblocks?

--- a/my_door_wood/init.lua
+++ b/my_door_wood/init.lua
@@ -22,6 +22,15 @@ minetest.register_node("my_door_wood:wood_"..color, {
 
 })
 
+if minetest.get_modpath("moreblocks") then
+stairsplus:register_all("my_door_wood", color, "my_door_wood:wood_"..color, {
+       description = desc.." Wood",
+       tiles = {"mydoors_"..img.."_wood.png"},
+       groups = {cracky = 2, choppy = 2},
+        sounds = default.node_sound_wood_defaults(),
+})
+end
+
 -- Crafts
 
 minetest.register_craft({


### PR DESCRIPTION
This change allows intermediate wood types to be used with stairsplus for stairs, slabs, etc.