### PR TITLE
Remove doors from itemstacks in custom on_place callbacks

### DIFF
--- a/my_future_doors/sliding.lua
+++ b/my_future_doors/sliding.lua
@@ -77,7 +77,10 @@ local function onplace(itemstack, placer, pointed_thing)
 				minetest.set_node(pt, {name=doora, param2=p2})
 				minetest.set_node(pt2, {name=doorb, param2=p2})
 			end
-		itemstack: take_item()
+
+		if not (minetest.settings:get_bool("creative_mode") or minetest.check_player_privs(placer:get_player_name(), {creative = true})) then
+			itemstack:take_item()
+		end
 		return itemstack
 end
 

--- a/my_garage_door/init.lua
+++ b/my_garage_door/init.lua
@@ -30,6 +30,11 @@ minetest.register_node("my_garage_door:garage_door", {
 print(p2)
 		minetest.set_node(p, {name = "my_garage_door:garage_door",param2 = p2})
 		minetest.set_node({x=p.x,y=p.y+1,z=p.z}, {name = "my_garage_door:garage_door_top",param2 = p2})
+
+		if not (minetest.settings:get_bool("creative_mode") or minetest.check_player_privs(placer:get_player_name(), {creative = true})) then
+			itemstack:take_item()
+		end
+		return itemstack
 	end,
 	after_destruct = function(pos, oldnode)
 		minetest.set_node({x=pos.x,y=pos.y+1,z=pos.z},{name = "air"})

--- a/my_misc_doors/bars.lua
+++ b/my_misc_doors/bars.lua
@@ -67,6 +67,11 @@ on_place = function(itemstack, placer, pointed_thing)
 				minetest.set_node(pt, {name="my_misc_doors:door2a", param2=p2})
 				minetest.set_node(pt2, {name="my_misc_doors:door2b", param2=p2})
 			end
+
+	if not (minetest.settings:get_bool("creative_mode") or minetest.check_player_privs(placer:get_player_name(), {creative = true})) then
+		itemstack:take_item()
+	end
+	return itemstack
 end,
 after_destruct = function(pos, oldnode)
 	   minetest.set_node({x=pos.x,y=pos.y+1,z=pos.z},{name="air"})

--- a/my_sliding_doors/jdoors1.lua
+++ b/my_sliding_doors/jdoors1.lua
@@ -29,6 +29,11 @@ function onplace(itemstack, placer, pointed_thing)
 			minetest.set_node({x=pos.x,y=pos.y+1,z=pos.z}, {name=doorb.."2",param2=par2})
 		end
 
+	if not (minetest.settings:get_bool("creative_mode") or minetest.check_player_privs(placer:get_player_name(), {creative = true})) then
+		itemstack:take_item()
+	end
+	return itemstack
+
 end
 
 function afterdestruct(pos, oldnode)
@@ -316,6 +321,11 @@ minetest.register_node("my_sliding_doors:jpanel"..num, {
 	else
 		return
 	end
+
+		if not (minetest.settings:get_bool("creative_mode") or minetest.check_player_privs(placer:get_player_name(), {creative = true})) then
+			itemstack:take_item()
+		end
+		return itemstack
 	end,
 	on_destruct = function(pos)
 		minetest.set_node({x=pos.x,y=pos.y+1,z=pos.z},{name="air"})
@@ -397,6 +407,11 @@ minetest.register_node("my_sliding_doors:jpanel_corner_"..num, {
 	else
 		return
 	end
+
+		if not (minetest.settings:get_bool("creative_mode") or minetest.check_player_privs(placer:get_player_name(), {creative = true})) then
+			itemstack:take_item()
+		end
+		return itemstack
 	end,
 	on_destruct = function(pos)
 		minetest.set_node({x=pos.x,y=pos.y+1,z=pos.z},{name="air"})

--- a/my_sliding_doors/jdoors2.lua
+++ b/my_sliding_doors/jdoors2.lua
@@ -46,6 +46,11 @@ function onplace(itemstack, placer, pointed_thing)
 		minetest.set_node(pt, {name=doora.."2", param2=p2})
 		minetest.set_node(pt2, {name=doorb.."2", param2=p2})
 	end
+
+	if not (minetest.settings:get_bool("creative_mode") or minetest.check_player_privs(placer:get_player_name(), {creative = true})) then
+		itemstack:take_item()
+	end
+	return itemstack
 end
 
 function afterdestruct(pos, oldnode)


### PR DESCRIPTION
Fixes #18 

Check for creative and remove an item from the itemstack if a player does not have creative - was previously causing duplication of doors when you pick the door back up 