### PR TITLE
Add mesecons support for locked doors

### DIFF
--- a/my_castle_doors/locked.lua
+++ b/my_castle_doors/locked.lua
@@ -15,7 +15,7 @@ local cdoor_list = {   --Number , Description , Inven Image , Image
 }
 
 local function add_door(desc, img)
-	doors.register("my_castle_doors:"..img.."_locked", {
+	mydoors.register_door("my_castle_doors:"..img.."_locked", {
 		description = desc.." Locked",
 		inventory_image = "mydoors_"..img.."_inv.png",
 		groups = {choppy=2,cracky=2,door=1},

--- a/my_cottage_doors/locked.lua
+++ b/my_cottage_doors/locked.lua
@@ -4,7 +4,7 @@ local cdoor_list = {   --Number , Description , Inven Image , Image
 }
 
 local function add_door(desc, img)
-	doors.register_door("my_cottage_doors:"..img.."_locked", {
+	mydoors.register_door("my_cottage_doors:"..img.."_locked", {
 		description = desc.." Locked",
 		inventory_image = "mycdoors_"..img.."_inv.png",
 		groups = {choppy=2,cracky=2,door=1},

--- a/my_default_doors/locked.lua
+++ b/my_default_doors/locked.lua
@@ -7,7 +7,7 @@ local cdoor_list = {   --Number , Description , Inven Image , Image
 }
 
 local function add_door(num, desc, img, itm)
-	doors.register_door("my_default_doors:door"..num.."_locked", {
+	mydoors.register_door("my_default_doors:door"..num.."_locked", {
 		description = desc.." Locked",
 		inventory_image = "mydoors_"..img.."_inv.png",
 		groups = {choppy=2,cracky=2,door=1},

--- a/my_fancy_doors/locked.lua
+++ b/my_fancy_doors/locked.lua
@@ -10,7 +10,7 @@ local fdoor_list = {   --Number , Description , Inven Image , Image
 }
 
 local function add_door(desc, img)
-	doors.register_door("my_fancy_doors:"..img.."_locked", {
+	mydoors.register_door("my_fancy_doors:"..img.."_locked", {
 		description = desc.." Locked",
 		inventory_image = "myfdoors_"..img.."_inv.png",
 		groups = {choppy=2,cracky=2,door=1},

--- a/my_hidden_doors/init.lua
+++ b/my_hidden_doors/init.lua
@@ -12,7 +12,7 @@ local hdoor_list = {   --Number , Description , default image
 
 local function add_door(img, desc)
 	-- Cannot add locked doors because the tooltip defies the purpose of being a hidden door
-	doors.register_door("my_hidden_doors:hidden_door"..img, {
+	mydoors.register_door("my_hidden_doors:hidden_door"..img, {
 		description = desc,
 		inventory_image = "mydoors_"..img.."_inv.png",
 		groups = {choppy=2,cracky=2,door=1},
@@ -26,7 +26,7 @@ for _,hdoor in ipairs(hdoor_list) do
 	add_door(unpack(hdoor))
 end
 
-doors.register_door("my_hidden_doors:hidden_door_grey", {
+mydoors.register_door("my_hidden_doors:hidden_door_grey", {
 	description = "Grey Door",
 	inventory_image = "mydoors_grey_inv.png",
 	groups = {choppy=2,cracky=2,door=1},

--- a/my_misc_doors/locked.lua
+++ b/my_misc_doors/locked.lua
@@ -7,7 +7,7 @@ local mdoor_list = {   --Number , Description , Inven Image , Image
 }
 
 local function add_door(desc, img)
-	doors.register_door("my_misc_doors:"..img.."_locked", {
+	mydoors.register_door("my_misc_doors:"..img.."_locked", {
 		description = desc.." Locked",
 		inventory_image = "mymdoors_"..img.."_inv.png",
 		groups = {choppy=2,cracky=2,door=1},

--- a/my_old_doors/locked.lua
+++ b/my_old_doors/locked.lua
@@ -6,7 +6,7 @@ local cdoor_list = {   --Number , Description , Inven Image , Image
 }
 
 local function add_door(num, desc, img)
-	doors.register_door("my_old_doors:door"..num.."_locked", {
+	mydoors.register_door("my_old_doors:door"..num.."_locked", {
 		description = desc.." Locked",
 		inventory_image = "mydoors_"..img.."_inv.png",
 		groups = {choppy=2,cracky=2,door=1},


### PR DESCRIPTION
Related: https://github.com/minetest-mods/mydoors/pull/24

This adds mesecons support for all locked doors. I've seen several players on different servers wondering why every door except 'mydoors locked doors' can be used with mesecons.

I add a setting for this if needed.