### PR TITLE
Make 'screwdriver' optional

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,7 +2,10 @@ unused_args = false
 max_line_length = 140
 
 read_globals = {
+    table = {fields = {"copy"}},
+
 	"minetest",
+	"core",
 	"vector",
 	"default",
 	"doors",

--- a/my_future_doors/framed.lua
+++ b/my_future_doors/framed.lua
@@ -1,3 +1,4 @@
+local rotate_disallow = rawget(_G, "screwdriver") and screwdriver.disallow or nil
 local doorcolors = {"white","red","black"}
 
 local function add_door(col)
@@ -36,7 +37,7 @@ local function add_door(col)
 				{-0.625,     1.4375,-0.5625,  0.625,  1.625,  0.5625}, --top
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 		on_place = function(itemstack, placer, pointed_thing)
 			local pos1 = pointed_thing.above
 			local pos2 = vector.add(pos1, {x=0,y=1,z=0})
@@ -112,7 +113,7 @@ local function add_door(col)
 				{-0.5, -0.5, -0.5, -0.5, -0.5, -0.5},
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 	})
 	minetest.register_node("my_future_doors:door1c_"..col, {
 		tiles = {
@@ -147,7 +148,7 @@ local function add_door(col)
 			}
 		},
 		drop = "my_future_doors:door1a_"..col,
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 		after_place_node = function(pos, placer, itemstack, pointed_thing)
 			local node = minetest.get_node(pos)
 			local timer = minetest.get_node_timer(pos)
@@ -196,7 +197,7 @@ local function add_door(col)
 				{-0.5, -0.5, -0.5, -0.5, -0.5, -0.5},
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 	})
 	minetest.register_craft({
 		output = "my_future_doors:door1a_"..col.." 1",

--- a/my_future_doors/mod.conf
+++ b/my_future_doors/mod.conf
@@ -1,3 +1,4 @@
 name = my_future_doors
 description = Futuristic style doors.
-depends = my_door_wood, screwdriver
+depends = my_door_wood
+optional_depends = screwdriver

--- a/my_future_doors/sliding.lua
+++ b/my_future_doors/sliding.lua
@@ -1,3 +1,5 @@
+local rotate_disallow = rawget(_G, "screwdriver") and screwdriver.disallow or nil
+
 local doors = {
 	{"my_future_doors:door2a","my_future_doors:door2b","my_future_doors:door2c","my_future_doors:door2d","2","Steel",
 			{{"default:steel_ingot", "default:steelblock", ""},
@@ -147,7 +149,7 @@ local function add_door(doora, doorb, doorc, doord, num, des, recipe)
 				{-0.5, -0.5, -0.0625, 0.5, 1.5, 0.0625}
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 
 		on_place = onplace,
 
@@ -180,7 +182,7 @@ local function add_door(doora, doorb, doorc, doord, num, des, recipe)
 				{0, 0, 0, 0, 0, 0},
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 	})
 	minetest.register_node(doorc, {
 		tiles = {
@@ -211,7 +213,7 @@ local function add_door(doora, doorb, doorc, doord, num, des, recipe)
 		after_place_node = afterplace,
 		after_destruct = afterdestruct,
 		on_timer = ontimer,
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 	})
 	minetest.register_node(doord, {
 		tiles = {
@@ -238,7 +240,7 @@ local function add_door(doora, doorb, doorc, doord, num, des, recipe)
 				{0, 0, 0, 0, 0, 0},
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 	})
 	minetest.register_craft({
 		output = "my_future_doors:door"..num.."a 2",

--- a/my_garage_door/init.lua
+++ b/my_garage_door/init.lua
@@ -1,3 +1,5 @@
+local rotate_disallow = rawget(_G, "screwdriver") and screwdriver.disallow or nil
+
 local function buildable_to(pos)
 	local node = minetest.get_node(pos).name
 	if minetest.registered_nodes[node] then -- The checked node is maybe an unknown node
@@ -5,6 +7,17 @@ local function buildable_to(pos)
 	end
 	return false
 end
+
+local nodebox_closed = {
+	type = "fixed",
+	fixed = {
+		{-1.5, -0.5,  -0.125,  1.5,  0.5,       -0.0625},
+		{-1.5, -0.5,  -0.1875, 1.5, -0.3125,    -0.0625},
+		{-1.5, -0.25, -0.1875, 1.5, -0.0624999, -0.0625},
+		{-1.5,  0,    -0.1875, 1.5,  0.1875,    -0.0625},
+		{-1.5,  0.25, -0.1875, 1.5,  0.4375,    -0.0625},
+	}
+}
 
 minetest.register_node("my_garage_door:garage_door", {
 	description = "Garage Door",
@@ -15,23 +28,14 @@ minetest.register_node("my_garage_door:garage_door", {
 	paramtype = "light",
 	paramtype2 = "facedir",
 	groups = {cracky=3},
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-1.5, -0.5,  -0.125,  1.5,  0.5,       -0.0625},
-			{-1.5, -0.5,  -0.1875, 1.5, -0.3125,    -0.0625},
-			{-1.5, -0.25, -0.1875, 1.5, -0.0624999, -0.0625},
-			{-1.5,  0,    -0.1875, 1.5,  0.1875,    -0.0625},
-			{-1.5,  0.25, -0.1875, 1.5,  0.4375,    -0.0625},
-		}
-	},
+	node_box = table.copy(nodebox_closed),
 	selection_box = {
 		type = "fixed",
 		fixed = {
 			{-1.5, -0.5, -0.1875, 1.5, 1.5, -0.0625},
 		}
 	},
-	on_rotate = screwdriver.disallow,
+	on_rotate = rotate_disallow,
 	on_place = function(itemstack, placer, pointed_thing)
 		local pos1 = pointed_thing.above
 		local pos2 = vector.add(pos1, {x=0,y=1,z=0})
@@ -114,19 +118,22 @@ minetest.register_node("my_garage_door:garage_door_top", {
 	diggable = false,
 	pointable = false,
 	groups = {cracky=3},
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-1.5, -0.5,  -0.125,  1.5,  0.5,       -0.0625},
-			{-1.5, -0.5,  -0.1875, 1.5, -0.3125,    -0.0625},
-			{-1.5, -0.25, -0.1875, 1.5, -0.0624999, -0.0625},
-			{-1.5,  0,    -0.1875, 1.5,  0.1875,    -0.0625},
-			{-1.5,  0.25, -0.1875, 1.5,  0.4375,    -0.0625},
-		}
-	},
+	node_box = table.copy(nodebox_closed),
 	selection_box = {type = "fixed",fixed = {{0, 0, 0, 0, 0, 0},}},
-	on_rotate = screwdriver.disallow,
+	on_rotate = rotate_disallow,
 })
+
+local nodebox_open = {
+	type = "fixed",
+	fixed = {
+		{-1.5, 0.4375, -0.5,    1.5, 0.375, 0.5},
+		{-1.5, 0.375,   0.3125, 1.5, 0.5,   0.5},
+		{-1.5, 0.375,   0.0625, 1.5, 0.5,   0.25},
+		{-1.5, 0.375,  -0.1875, 1.5, 0.5,   0},
+		{-1.5, 0.375,  -0.4375, 1.5, 0.5,  -0.25},
+	}
+}
+
 minetest.register_node("my_garage_door:garage_door_open", {
 	tiles = {
 		"default_snow.png"
@@ -137,18 +144,9 @@ minetest.register_node("my_garage_door:garage_door_open", {
 	drop = "my_garage_door:garage_door",
 	diggable = false,
 	groups = {cracky=3},
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-1.5, 0.4375, -0.5,    1.5, 0.375, 0.5},
-			{-1.5, 0.375,   0.3125, 1.5, 0.5,   0.5},
-			{-1.5, 0.375,   0.0625, 1.5, 0.5,   0.25},
-			{-1.5, 0.375,  -0.1875, 1.5, 0.5,   0},
-			{-1.5, 0.375,  -0.4375, 1.5, 0.5,  -0.25},
-		}
-	},
+	node_box = table.copy(nodebox_open),
 	selection_box = {type = "fixed",fixed = {{-1.5, 0.375, -0.5, 1.5, 0.5, 1.5},}},
-	on_rotate = screwdriver.disallow,
+	on_rotate = rotate_disallow,
 	on_rightclick = function(pos, node, player, itemstack, pointed_thing)
 		local p2 = node.param2
 		local dir = minetest.facedir_to_dir((p2+2)%4)
@@ -195,18 +193,9 @@ minetest.register_node("my_garage_door:garage_door_open2", {
 	diggable = false,
 	pointable = false,
 	groups = {cracky=3},
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-1.5, 0.4375, -0.5,    1.5, 0.375, 0.5},
-			{-1.5, 0.375,   0.3125, 1.5, 0.5,   0.5},
-			{-1.5, 0.375,   0.0625, 1.5, 0.5,   0.25},
-			{-1.5, 0.375,  -0.1875, 1.5, 0.5,   0},
-			{-1.5, 0.375,  -0.4375, 1.5, 0.5,  -0.25},
-		}
-	},
+	node_box = table.copy(nodebox_open),
 	selection_box = {type = "fixed",fixed = {{0, 0, 0, 0, 0, 0},}},
-	on_rotate = screwdriver.disallow,
+	on_rotate = rotate_disallow,
 })
 
 -- craft

--- a/my_garage_door/mod.conf
+++ b/my_garage_door/mod.conf
@@ -1,3 +1,3 @@
 name = my_garage_door
 description = A garage door.
-optional_depends = basic_materials
+optional_depends = basic_materials, screwdriver

--- a/my_misc_doors/bars.lua
+++ b/my_misc_doors/bars.lua
@@ -1,3 +1,16 @@
+local rotate_disallow = rawget(_G, "screwdriver") and screwdriver.disallow or nil
+
+local nodebox = {
+	type = "fixed",
+	fixed = {
+		{-0.4375, -0.5, -0.0625, -0.3125, 0.5, 0.0625},
+		{-0.0625, -0.5, -0.0625,  0.0625, 0.5, 0.0625},
+		{ 0.3125, -0.5, -0.0625,  0.4375, 0.5, 0.0625},
+		{ 0.125,  -0.5, -0.0625,  0.25,   0.5, 0.0625},
+		{-0.25,   -0.5, -0.0625, -0.125,  0.5, 0.0625},
+	}
+}
+
 minetest.register_node("my_misc_doors:door2a", {
 	description = "Sliding Door",
 	inventory_image = "mydoors_bars.png",
@@ -13,23 +26,14 @@ minetest.register_node("my_misc_doors:door2a", {
 	paramtype = "light",
 	paramtype2 = "facedir",
 	groups = {cracky = 3},
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.4375, -0.5, -0.0625, -0.3125, 0.5, 0.0625},
-			{-0.0625, -0.5, -0.0625,  0.0625, 0.5, 0.0625},
-			{ 0.3125, -0.5, -0.0625,  0.4375, 0.5, 0.0625},
-			{ 0.125,  -0.5, -0.0625,  0.25,   0.5, 0.0625},
-			{-0.25,   -0.5, -0.0625, -0.125,  0.5, 0.0625},
-		}
-	},
+	node_box = table.copy(nodebox),
 	selection_box = {
 		type = "fixed",
 		fixed = {
 			{-0.4375, -0.5, -0.0625, 0.4375, 1.5, 0.0625},
 		}
 	},
-	on_rotate = screwdriver.disallow,
+	on_rotate = rotate_disallow,
 
 	on_place = function(itemstack, placer, pointed_thing)
 		local pos1 = pointed_thing.above
@@ -102,23 +106,14 @@ minetest.register_node("my_misc_doors:door2b", {
 	paramtype = "light",
 	paramtype2 = "facedir",
 	groups = {cracky = 1},
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.4375, -0.5, -0.0625, -0.3125, 0.5, 0.0625},
-			{-0.0625, -0.5, -0.0625,  0.0625, 0.5, 0.0625},
-			{ 0.3125, -0.5, -0.0625,  0.4375, 0.5, 0.0625},
-			{ 0.125,  -0.5, -0.0625,  0.25,   0.5, 0.0625},
-			{-0.25,   -0.5, -0.0625, -0.125,  0.5, 0.0625},
-		}
-	},
+	node_box = table.copy(nodebox),
 	selection_box = {
 		type = "fixed",
 		fixed = {
 			{0, 0, 0, 0, 0, 0},
 		}
 	},
-	on_rotate = screwdriver.disallow,
+	on_rotate = rotate_disallow,
 })
 minetest.register_node("my_misc_doors:door2c", {
 	tiles = {
@@ -150,7 +145,7 @@ minetest.register_node("my_misc_doors:door2c", {
 		}
 	},
 	drop = "my_misc_doors:door2a",
-	on_rotate = screwdriver.disallow,
+	on_rotate = rotate_disallow,
 	after_place_node = function(pos, placer, itemstack, pointed_thing)
 		local node = minetest.get_node(pos)
 		local timer = minetest.get_node_timer(pos)
@@ -206,7 +201,7 @@ minetest.register_node("my_misc_doors:door2d", {
 			{0, 0, 0, 0, 0, 0},
 		}
 	},
-	on_rotate = screwdriver.disallow,
+	on_rotate = rotate_disallow,
 })
 minetest.register_craft({
 	output = "my_misc_doors:door2a 1",

--- a/my_misc_doors/mod.conf
+++ b/my_misc_doors/mod.conf
@@ -1,3 +1,4 @@
 name = my_misc_doors
 description = Some misc. doors.
-depends = default, my_door_wood, doors, wool, screwdriver
+depends = default, my_door_wood, doors, wool
+optional_depends = screwdriver

--- a/my_saloon_doors/init.lua
+++ b/my_saloon_doors/init.lua
@@ -1,3 +1,5 @@
+local rotate_simple = rawget(_G, "screwdriver") and screwdriver.rotate_simple or nil
+
 local doorcol = {
 	{"white",	"White",	"^[colorize:white:120", "my_door_wood:wood_white"},
 	{"red",		"Red",		"^[colorize:red:120", "my_door_wood:wood_red"},
@@ -37,7 +39,7 @@ local function add_door(col, des, tint, craft)
 				{-0.5, -0.1875, -0.0625, 0.5, 1, 0.0625},
 			}
 		},
-		on_rotate = screwdriver.rotate_simple,
+		on_rotate = rotate_simple,
 
 		on_place = function(itemstack, placer, pointed_thing)
 			local pos1 = pointed_thing.above
@@ -107,7 +109,7 @@ local function add_door(col, des, tint, craft)
 				{0, 0, 0, 0, 0, 0},
 			}
 		},
-		on_rotate = screwdriver.rotate_simple,
+		on_rotate = rotate_simple,
 		on_timer = function(pos, elapsed)
 			local node = minetest.get_node(pos)
 			minetest.set_node(pos, {name="my_saloon_doors:door1a_"..col, param2=node.param2})

--- a/my_saloon_doors/mod.conf
+++ b/my_saloon_doors/mod.conf
@@ -1,3 +1,4 @@
 name = my_saloon_doors
 description = Saloon style doors.
-depends = default, my_door_wood, doors, screwdriver
+depends = default, my_door_wood, doors
+optional_depends = screwdriver

--- a/my_sliding_doors/jdoors1.lua
+++ b/my_sliding_doors/jdoors1.lua
@@ -1,3 +1,5 @@
+local rotate_disallow = rawget(_G, "screwdriver") and screwdriver.disallow or nil
+
 local doors = {
 	{"my_sliding_doors:door1a","my_sliding_doors:door1b","my_sliding_doors:door1c","my_sliding_doors:door1d","1","White"},
 	{"my_sliding_doors:door2a","my_sliding_doors:door2b","my_sliding_doors:door2c","my_sliding_doors:door2d","2","Flower"},
@@ -130,12 +132,9 @@ local function add_door(doora, doorb, doorc, doord, num, des)
 				{-0.5, -0.5,  0.0625,  0.5, 1.5, 0.1875}
 			}
 		},
-		on_rotate = screwdriver.disallow,
-
+		on_rotate = rotate_disallow,
 		on_place = onplace,
-
 		after_destruct = afterdestruct,
-
 		on_rightclick = rightclick,
 	})
 	minetest.register_node(doorb, {
@@ -174,7 +173,7 @@ local function add_door(doora, doorb, doorc, doord, num, des)
 				{0, 0, 0, 0, 0, 0},
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 	})
 	minetest.register_node(doorc, {
 		tiles = {
@@ -213,7 +212,7 @@ local function add_door(doora, doorb, doorc, doord, num, des)
 				{-1.5, -0.5, -0.0625, -0.5, 1.5, 0.1875}
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 		after_place_node = afterplace,
 		after_destruct = afterdestruct,
 		on_rightclick = rightclick,
@@ -254,7 +253,7 @@ local function add_door(doora, doorb, doorc, doord, num, des)
 				{0, 0, 0, 0, 0, 0},
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 	})
 	minetest.register_node("my_sliding_doors:jpanel"..num, {
 		description = des.." Panel",
@@ -284,7 +283,7 @@ local function add_door(doora, doorb, doorc, doord, num, des)
 		},
 		selection_box = {type = "fixed", fixed = {{-0.5, -0.5, -0.0625, 0.5, 1.5, 0.0625}}},
 		collision_box = {type = "fixed", fixed = {{-0.5, -0.5, -0.0625, 0.5, 1.5, 0.0625}}},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 
 		on_place = function(itemstack, placer, pointed_thing)
 			local p2 = minetest.dir_to_facedir(placer:get_look_dir())
@@ -358,7 +357,7 @@ local function add_door(doora, doorb, doorc, doord, num, des)
 				{0, 0, 0, 0, 0, 0}
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 	})
 	minetest.register_node("my_sliding_doors:jpanel_corner_"..num, {
 		description = des.." Panel Corner",
@@ -395,7 +394,7 @@ local function add_door(doora, doorb, doorc, doord, num, des)
 				{-0.5,    -0.5, -0.0625, 0,      1.5, 0.0625},
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 		on_place = function(itemstack, placer, pointed_thing)
 			local p2 = minetest.dir_to_facedir(placer:get_look_dir())
 			local pos = pointed_thing.above
@@ -470,7 +469,7 @@ local function add_door(doora, doorb, doorc, doord, num, des)
 				{0, 0, 0, 0, 0, 0}
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 	})
 end
 

--- a/my_sliding_doors/jdoors2.lua
+++ b/my_sliding_doors/jdoors2.lua
@@ -1,3 +1,5 @@
+local rotate_disallow = rawget(_G, "screwdriver") and screwdriver.disallow
+
 local doors = {
 	{"my_sliding_doors:door1a","my_sliding_doors:door1b","my_sliding_doors:door1c","my_sliding_doors:door1d","1","White Right"},
 	{"my_sliding_doors:door2a","my_sliding_doors:door2b","my_sliding_doors:door2c","my_sliding_doors:door2d","2","Flower Right"},
@@ -133,12 +135,9 @@ local function add_door(doora, doorb, doorc, doord, num)
 				{-0.5, -0.5, -0.0625,  0.5, 1.5, -0.1875}
 			}
 		},
-		on_rotate = screwdriver.disallow,
-
+		on_rotate = rotate_disallow,
 		on_place = onplace,
-
 		after_destruct = afterdestruct,
-
 		on_rightclick = rightclick,
 	})
 	minetest.register_node(doorb.."2", {
@@ -177,7 +176,7 @@ local function add_door(doora, doorb, doorc, doord, num)
 				{0, 0, 0, 0, 0, 0},
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 	})
 	minetest.register_node(doorc.."2", {
 		tiles = {
@@ -216,7 +215,7 @@ local function add_door(doora, doorb, doorc, doord, num)
 				{-1.5, -0.5, 0.0625, -0.5, 1.5, -0.1875}
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 		after_place_node = afterplace,
 		after_destruct = afterdestruct,
 		on_rightclick = rightclick,
@@ -257,7 +256,7 @@ local function add_door(doora, doorb, doorc, doord, num)
 				{0, 0, 0, 0, 0, 0},
 			}
 		},
-		on_rotate = screwdriver.disallow,
+		on_rotate = rotate_disallow,
 	})
 end
 

--- a/my_sliding_doors/mod.conf
+++ b/my_sliding_doors/mod.conf
@@ -1,3 +1,4 @@
 name = my_sliding_doors
 description = Shoji sliding doors and panels.
-depends = default, flowers, screwdriver
+depends = default, flowers
+optional_depends = screwdriver


### PR DESCRIPTION
This eases the integration for other games. The screwdriver API should still be provided when needed to avoid incorrect node rotations.

Fixes #38

@MoNTE48 Please confirm whether this solves your issue.