### PR TITLE
Remove Unused Dependency

### DIFF
--- a/my_default_doors/mod.conf
+++ b/my_default_doors/mod.conf
@@ -1,3 +1,3 @@
 name = my_default_doors
 description = Doors made from default ores. Copper, bronze, gold, diamond and mese.
-depends = default, my_door_wood, doors
+depends = default, doors


### PR DESCRIPTION
Removes unused dependency on `my_door_wood` in `my_default_doors`.